### PR TITLE
chore: bump Go to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/elastic/go-grok
 
-go 1.22.0
-
-toolchain go1.24.2
+go 1.26.0
 
 replace github.com/elastic/go-grok/dev-tools/mage => ./devtools/mage
 


### PR DESCRIPTION
## Summary
- Bumps `go` directive in `go.mod` to `1.26.0`
- Runs `go mod tidy` to update `go.sum`

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Go version/toolchain metadata change only; risk is limited to build/CI compatibility with the new Go version.
> 
> **Overview**
> Updates the module to target **Go 1.26.0** by changing the `go` directive in `go.mod` and removing the pinned `toolchain go1.24.2` line.
> 
> No application code changes; this is a build/tooling version bump that may affect CI and local builds depending on Go availability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e28a53abb36c8188ff7a486cb90f253b03be386e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump the module to Go 1.26.0 and remove the toolchain directive to standardize builds on 1.26 and unlock new language/runtime features.

- **Migration**
  - Install Go 1.26+ locally and rebuild.
  - Ensure CI and container images use Go 1.26.

<sup>Written for commit e28a53abb36c8188ff7a486cb90f253b03be386e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

